### PR TITLE
Fix 'CONFIGURE_EXTRA_OPTS: unbound variable' regression

### DIFF
--- a/build_automation/gpdb/scripts/configure-gpdb.sh
+++ b/build_automation/gpdb/scripts/configure-gpdb.sh
@@ -139,7 +139,7 @@ execute_cmd ./configure --with-perl --with-python --with-libxml --enable-mapredu
         --with-system-tzdata=/usr/share/zoneinfo \
         --enable-orafce \
         --without-mdblocales \
-        --with-zstd ${CONFIGURE_EXTRA_OPTS}
+        --with-zstd ${CONFIGURE_EXTRA_OPTS:-""}
 
 log_section_end "Configure"
 


### PR DESCRIPTION
Fix regression:
```
configure-gpdb.sh: line 127: CONFIGURE_EXTRA_OPTS: unbound variable
```
https://github.com/open-gpdb/gpdb/actions/runs/13951459481/job/39051811835?pr=159