### PR TITLE
Add missing dependencies and env var for regression tests

### DIFF
--- a/build_automation/gpdb/scripts/test-gpdb.sh
+++ b/build_automation/gpdb/scripts/test-gpdb.sh
@@ -56,6 +56,7 @@
 set -euo pipefail
 
 export BUILD_DESTINATION="/opt/greenplum-db-6"
+export PGOPTIONS="${PGOPTIONS:--c optimizer=on}"
 
 # Source common utilities
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/images/docker/gpdb/build/jammy/Dockerfile
+++ b/images/docker/gpdb/build/jammy/Dockerfile
@@ -93,10 +93,11 @@ RUN apt-get update -o Acquire::AllowInsecureRepositories=true && apt-get install
   software-properties-common \
   openssh-client \
   openssh-server \
-  locales
+  locales \
+  postgresql-client
 
 
-RUN pip2 install psutil
+RUN pip2 install psutil pyyaml
 
 RUN apt-get install -y locales \
 && locale-gen "en_US.UTF-8" \
@@ -130,6 +131,7 @@ RUN echo ${TIMEZONE_VAR} > /etc/timezone && \
     update-locale LC_ALL="en_US.UTF-8"
 
 USER gpadmin
+ENV USER=gpadmin
 WORKDIR /home/gpadmin
 
 RUN sudo DEBIAN_FRONTEND=noninteractive apt install -y libhyperic-sigar-java libaprutil1-dev libuv1-dev


### PR DESCRIPTION
Add missing dependencies and env var for regression tests

Fixed several test failures:
* Added `postgresql-client` - starting demo-cluster requires psql.
* Added `pyyaml` - standby master requires `pyyaml` for initialization.
* Set `USER=gpadmin` - some tests rely on USER env var being set.
* Added `PGOPTIONS="-c optimizer=on"` - fixes `explain_format_optimizer` and other GPORCA tests.

Still failing:
* `timestamptz` - container has newer `tzdata` version, causing different timestamp outputs.
* `misc` - expected failure (disabled mdb locale).
* `gp_check_files` - profiling cleanup logs `"gmon.out: No such file or directory"`.