### PR TITLE
use mirror.yandex.ru for jammy repos

### DIFF
--- a/images/docker/gpdb/build/22.04/Dockerfile
+++ b/images/docker/gpdb/build/22.04/Dockerfile
@@ -18,7 +18,8 @@ ARG TIMEZONE_VAR="Europe/London"
 # --------------------------------------------------------------------
 # Install Development Tools and Utilities
 # --------------------------------------------------------------------
-RUN apt-get update -o Acquire::AllowInsecureRepositories=true && apt-get install -y --no-install-recommends --allow-unauthenticated \
+RUN sed -i "s/archive.ubuntu.com/mirror.yandex.ru/g" /etc/apt/sources.list && \
+  apt-get update -o Acquire::AllowInsecureRepositories=true && apt-get install -y --no-install-recommends --allow-unauthenticated \
   bison \
   build-essential \
   ca-certificates \


### PR DESCRIPTION
mirror.yandex.ru is more stable then archive.ubuntu.com

I've got numerous times "403 Forbidden" from archive.ubuntu.com. It's pure torture to use archive.ubuntu.