### PR TITLE
Fix maintainer info

### DIFF
--- a/packaging/deb/cbdb_jammy/debian/control
+++ b/packaging/deb/cbdb_jammy/debian/control
@@ -1,5 +1,5 @@
 Source: greenplum-db-cb
-Maintainer: Greenplum Release Engineering <release@greenplum.org>
+Maintainer: <opengpdb@yandex-team.ru>
 Section: database
 Build-Depends: debhelper (>= 9),
     bison,

--- a/packaging/deb/gpdb_bionic/debian/control
+++ b/packaging/deb/gpdb_bionic/debian/control
@@ -1,5 +1,5 @@
 Source: greenplum-db-6
-Maintainer: Greenplum Release Engineering <release@greenplum.org>
+Maintainer: <opengpdb@yandex-team.ru>
 Section: database
 Build-Depends: debhelper (>= 9),
     bison,

--- a/packaging/deb/jammy/debian/control
+++ b/packaging/deb/jammy/debian/control
@@ -1,5 +1,5 @@
 Source: greenplum-db-6
-Maintainer: open-gpdb dev team https://github.com/open-gpdb/gpdb
+Maintainer: open-gpdb dev team <opengpdb@yandex-team.ru> 
 Section: database
 Build-Depends: debhelper (>= 9),
     bison,

--- a/packaging/deb/pxf_6_bionic/debian/control
+++ b/packaging/deb/pxf_6_bionic/debian/control
@@ -1,6 +1,6 @@
 Source: greenplum-pxf-6
 Section: database
-Maintainer: <ostinru@localhost>
+Maintainer: <opengpdb@yandex-team.ru>
 Build-Depends: debhelper (>=9),
     bison,
     ca-certificates-java,

--- a/packaging/deb/pxf_6_jammy/debian/control
+++ b/packaging/deb/pxf_6_jammy/debian/control
@@ -1,6 +1,6 @@
 Source: greenplum-pxf-6
 Section: database
-Maintainer: <kashinav@localhost>
+Maintainer: <opengpdb@yandex-team.ru>
 Build-Depends: debhelper (>=9),
     bison,
     ca-certificates-java,

--- a/packaging/deb/pxf_cb_jammy/debian/control
+++ b/packaging/deb/pxf_cb_jammy/debian/control
@@ -1,6 +1,6 @@
 Source: greenplum-pxf-cb
 Section: database
-Maintainer: <ostinru@localhost>
+Maintainer: <opengpdb@yandex-team.ru>
 Build-Depends: debhelper (>=9),
     ca-certificates-java,
     ca-certificates,

--- a/packaging/deb/pxf_drivers/debian/control
+++ b/packaging/deb/pxf_drivers/debian/control
@@ -1,6 +1,6 @@
 Source: greenplum-pxf-drivers
 Section: database
-Maintainer: <ostinru@yandex-team.ru>
+Maintainer: <opengpdb@yandex-team.ru>
 Build-Depends: debhelper (>=9.0.0)
 
 Package: greenplum-pxf-drivers

--- a/packaging/open-gpdb/deb/18.04/control
+++ b/packaging/open-gpdb/deb/18.04/control
@@ -1,5 +1,5 @@
 Source: greenplum-db-6
-Maintainer: Greenplum Release Engineering <release@greenplum.org>
+Maintainer: <opengpdb@yandex-team.ru>
 Section: database
 Build-Depends: debhelper (>= 9),
     bison,

--- a/packaging/open-gpdb/deb/22.04/control
+++ b/packaging/open-gpdb/deb/22.04/control
@@ -1,5 +1,5 @@
 Source: greenplum-db-6
-Maintainer: open-gpdb dev team https://github.com/open-gpdb/gpdb
+Maintainer: open-gpdb dev team <opengpdb@yandex-team.ru> 
 Section: database
 Build-Depends: debhelper (>= 9),
     bison,

--- a/packaging/pxf/deb/18.04/control
+++ b/packaging/pxf/deb/18.04/control
@@ -1,6 +1,6 @@
 Source: greenplum-pxf-6
 Section: database
-Maintainer: <ostinru@localhost>
+Maintainer: <opengpdb@yandex-team.ru>
 Build-Depends: debhelper (>=9),
     bison,
     ca-certificates-java,

--- a/packaging/pxf/deb/22.04-cbdb/control
+++ b/packaging/pxf/deb/22.04-cbdb/control
@@ -1,6 +1,6 @@
 Source: greenplum-pxf-cb
 Section: database
-Maintainer: <ostinru@localhost>
+Maintainer: <opengpdb@yandex-team.ru>
 Build-Depends: debhelper (>=9),
     ca-certificates-java,
     ca-certificates,

--- a/packaging/pxf/deb/22.04/control
+++ b/packaging/pxf/deb/22.04/control
@@ -1,6 +1,6 @@
 Source: greenplum-pxf-6
 Section: database
-Maintainer: <kashinav@localhost>
+Maintainer: <opengpdb@yandex-team.ru>
 Build-Depends: debhelper (>=9),
     bison,
     ca-certificates-java,

--- a/packaging/pxf/deb/drivers/control
+++ b/packaging/pxf/deb/drivers/control
@@ -1,6 +1,6 @@
 Source: greenplum-pxf-drivers
 Section: database
-Maintainer: <ostinru@yandex-team.ru>
+Maintainer: <opengpdb@yandex-team.ru>
 Build-Depends: debhelper (>=9.0.0)
 
 Package: greenplum-pxf-drivers

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -68,7 +68,7 @@ ${PACKAGE} (${GPDB_PKG_VERSION}) stable; urgency=low
 
   * open-gpdb autobuild
 
-  -- ${BUILD_USER} <${BUILD_USER}@$(hostname)>  $(date +'%a, %d %b %Y %H:%M:%S %z')
+ -- ${BUILD_USER} <${BUILD_USER}@$(hostname)>  $(date +'%a, %d %b %Y %H:%M:%S %z')
 EOF
 }
 


### PR DESCRIPTION
We added an extra space to maintainer information and this led to the "Changed-by" field in the changes file not being filled. 

The changes file was incorrect and we had issues with package publishing. 

Here, I removed the extra space and fixed maintainer information in all control files.