### PR TITLE
[gp_stats_collector] Build by default

### DIFF
--- a/build_automation/gpdb/scripts/configure-gpdb.sh
+++ b/build_automation/gpdb/scripts/configure-gpdb.sh
@@ -144,6 +144,7 @@ execute_cmd ./configure --with-perl --with-python --with-libxml --enable-mapredu
         --prefix=${BUILD_DESTINATION} \
         ${CONFIGURE_DEBUG_OPTS} \
 	${CONFIGURE_PROFILING_OPTS} \
+        --with-gp-stats-collector \
         --with-ldap \
         --enable-gpperfmon \
         --with-pam \


### PR DESCRIPTION
Build gp-stats-collector by default,
similar to Cloudberry [0], so we
have the same configuration flow.

[0] https://github.com/apache/cloudberry/commit/7e12a9379e61690a287de371b6c302f3a5d8fe8a