### PR TITLE
PXF packages should depend on virtual java package, so users can choose JVM version

### DIFF
--- a/packaging/cloudberry-pxf/deb/22.04/control
+++ b/packaging/cloudberry-pxf/deb/22.04/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>=9),
 Package: cloudberry-pxf
 Architecture: amd64
 Depends: ca-certificates-java,
-  java-runtime-headless,
+  java8-runtime-headless,
   apache-cloudberry-db-incubating,
   curl,
   libcurl3-gnutls,

--- a/packaging/cloudberry-pxf/deb/22.04/control
+++ b/packaging/cloudberry-pxf/deb/22.04/control
@@ -10,18 +10,17 @@ Build-Depends: debhelper (>=9),
     libcurl4-gnutls-dev,
     libssl-dev,
     make,
-    openjdk-11-jdk-headless,
-    openjdk-11-jre-headless
+    openjdk-11-jdk-headless
 
 Package: cloudberry-pxf
 Architecture: amd64
 Depends: ca-certificates-java,
-  openjdk-11-jre-headless,
+  java-runtime-headless,
   apache-cloudberry-db-incubating,
   curl,
   libcurl3-gnutls,
   libcurl4
-Description: Cloudberry PXF 6 OSS
+Description: Cloudberry PXF
   The Cloudberry Platform Extension Framework (PXF) provides parallel, high
   throughput data access and federated queries across heterogeneous data
   sources via built-in connectors that map a Cloudberry Database external

--- a/packaging/cloudberry-pxf/deb/drivers/control
+++ b/packaging/cloudberry-pxf/deb/drivers/control
@@ -5,5 +5,5 @@ Build-Depends: debhelper (>=9.0.0)
 
 Package: cloudberry-pxf-drivers
 Architecture: any
-Depends: java-runtime-headless
+Depends: java8-runtime-headless
 Description: Drivers for Cloudberry PXF

--- a/packaging/cloudberry-pxf/deb/drivers/control
+++ b/packaging/cloudberry-pxf/deb/drivers/control
@@ -5,5 +5,5 @@ Build-Depends: debhelper (>=9.0.0)
 
 Package: cloudberry-pxf-drivers
 Architecture: any
-Depends: openjdk-11-jre-headless
+Depends: java-runtime-headless
 Description: Drivers for Cloudberry PXF

--- a/packaging/pxf/deb/22.04/control
+++ b/packaging/pxf/deb/22.04/control
@@ -10,13 +10,12 @@ Build-Depends: debhelper (>=9),
     libcurl4-gnutls-dev,
     libssl-dev,
     make,
-    openjdk-11-jdk-headless,
-    openjdk-11-jre-headless
+    openjdk-11-jdk-headless
 
 Package: greenplum-pxf-6
 Architecture: amd64
 Depends: ca-certificates-java,
-  openjdk-11-jre-headless,
+  java-runtime-headless,
   greenplum-db-6,
   curl,
   libcurl3-gnutls,

--- a/packaging/pxf/deb/22.04/control
+++ b/packaging/pxf/deb/22.04/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>=9),
 Package: greenplum-pxf-6
 Architecture: amd64
 Depends: ca-certificates-java,
-  java-runtime-headless,
+  java8-runtime-headless,
   greenplum-db-6,
   curl,
   libcurl3-gnutls,

--- a/packaging/pxf/deb/drivers/control
+++ b/packaging/pxf/deb/drivers/control
@@ -5,5 +5,5 @@ Build-Depends: debhelper (>=9.0.0)
 
 Package: greenplum-pxf-drivers
 Architecture: any
-Depends: java-runtime-headless
+Depends: java8-runtime-headless
 Description: Drivers for Greenplum PXF 6

--- a/packaging/pxf/deb/drivers/control
+++ b/packaging/pxf/deb/drivers/control
@@ -5,5 +5,5 @@ Build-Depends: debhelper (>=9.0.0)
 
 Package: greenplum-pxf-drivers
 Architecture: any
-Depends: openjdk-11-jre-headless
+Depends: java-runtime-headless
 Description: Drivers for Greenplum PXF 6


### PR DESCRIPTION
1. It is better to depend on virtual package - users will be free to choose an implementation.
2. Newer Java versions support older java version. e.g. `temurin-17-jdk` provides `java8-runtime-headless`. So, it is simple way to specify oldest supported java version